### PR TITLE
Several updates/enhancements

### DIFF
--- a/examples/auth_helper.rb
+++ b/examples/auth_helper.rb
@@ -1,0 +1,7 @@
+# Helper script to access TextMagic credentials stored as environment variables (preferred)
+# This will prevent you from accidentally committing your credentials to a repo
+
+def tm_credentials
+  username, api_key = ENV['TEXTMAGIC_USERNAME'], ENV['TEXTMAGIC_API_KEY']
+  return username, api_key if username and api_key
+end

--- a/examples/send_message.rb
+++ b/examples/send_message.rb
@@ -1,0 +1,46 @@
+require 'rubygems'
+require 'textmagic-ruby'
+require './auth_helper'
+
+# This is the preferred method to pass your API credentials
+# set the environment variables TEXTMAGIC_USERNAME and TEXTMAGIC_API_KEY in your shell
+user_name, api_key = tm_credentials
+
+# If you must, you can uncomment and assign the credential variables here
+# user_name = 'your_text_magic_username'
+# api_key = 'your_text_magic_api_key'
+
+begin
+  client = Textmagic::REST::Client.new user_name, api_key
+  # Any phone number that starts with 999 is a test phone number, replace the phones
+  # parameter with a real number to send an SMS message to an actual device
+  params = {phones: '999123456', text: 'Sample text!'}
+
+  # Sleep to avoid rate limiting
+  # See https://www.textmagic.com/docs/api/restrictions/#api-request-frequency-limit
+  sleep 1
+
+  # This line creates and sends the outgoing message
+  outgoing_message = client.messages.create(params)
+  puts "The message id is: #{outgoing_message.id}"
+  puts "The message URL is: #{outgoing_message.href}"
+  # See the full set of available properties here: https://www.textmagic.com/docs/api/send-sms/#response
+
+  sleep 1
+  # Now that we've sent the message, let's fetch data about it from the API
+  messages = client.messages.list(params)
+  sent_message = messages.resources.find { |m| m.id == outgoing_message.id }
+
+  # For more information about message statuses,
+  # see https://www.textmagic.com/docs/api/sms-sessions/#message-delivery-statuses
+  puts "The message status is: #{sent_message.status}"
+  puts "The sender's phone number is: #{sent_message.sender}"
+  puts "The message text: #{sent_message.text}"
+
+  # See the full set of available properties here:
+  # https://www.textmagic.com/docs/api/sms-sessions/#get-a-specific-message-details
+
+rescue Textmagic::REST::RequestError => e
+  puts e.message
+  puts e.backtrace
+end

--- a/lib/textmagic-ruby/rest/client.rb
+++ b/lib/textmagic-ruby/rest/client.rb
@@ -96,6 +96,19 @@ module Textmagic
         @conn.ca_file = File.dirname(__FILE__) + '/../../../conf/cacert.pem'
       end
 
+      # Unpack and return the nested error messages
+      def pretty_hash_message(msg_hash)
+        message = msg_hash['message']
+        if msg_hash['errors']
+          msg_hash['errors'].each do |k,v|
+            if msg_hash['errors'][k]
+              message = "#{message}:\n#{k}: #{v}"
+            end
+          end
+        end
+        message
+      end
+
       def make_request(request)
 
         response = @conn.request request
@@ -112,8 +125,13 @@ module Textmagic
           object = {:message => 'Bad request', :code => 400}
         end
 
+        message = nil
+        if object.is_a? Hash
+          message = pretty_hash_message(object)
+        end
+
         if response.kind_of? Net::HTTPClientError
-          raise Textmagic::REST::RequestError.new object['message'], object['code']
+          raise Textmagic::REST::RequestError.new message, object['code']
         end
         object
       end

--- a/lib/textmagic-ruby/rest/replies.rb
+++ b/lib/textmagic-ruby/rest/replies.rb
@@ -36,6 +36,9 @@ module Textmagic
       #   @replies = client.replies.list
       #
       def list(params={})
+        if params.has_key? :search
+          params.delete(:search) unless params[:search]
+        end
         super params
       end
 


### PR DESCRIPTION
Fixed the search parameter to Client.replies.list so that it honored truthy/falsey values
It was treating all values as true if the parameter was simply supplied, for example something like this would treat :search as true:

received_messages = client.replies.list(ids: '7917218,7917217', search: true)
