### PR TITLE
Minor validation fix, this prevents the confusing 'Resource does not …

### DIFF
--- a/lib/textmagic-ruby/rest/chats.rb
+++ b/lib/textmagic-ruby/rest/chats.rb
@@ -37,6 +37,9 @@ module Textmagic
       #   @chat_messages = client.chats.get_by_phone 99990000
       #
       def get_by_phone(phone, params={})
+        if phone.nil? or phone.empty?
+          raise Textmagic::REST::RequestError.new 'You must specify a valid E.164 phone number.'
+        end
         response = @client.get "#{@path}/#{phone}", params
         PaginateResource.new "#{@path}", @client, response, Textmagic::REST::ChatMessage
       end

--- a/spec/rest/chats_spec.rb
+++ b/spec/rest/chats_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Textmagic::REST::Chats do
+
+  it 'should set username and token when initialize' do
+    client = Textmagic::REST::Client.new 'mock_user', 'mock_key'
+    expect {client.chats.get_by_phone('')}.to raise_error Textmagic::REST::RequestError, 'You must specify a valid E.164 phone number.'
+  end
+
+end


### PR DESCRIPTION
…exist' error when nil or an empty string are passed as the phone number parameter.  Because of how the server API works, this seems like the only legitimate fix for this corner case.
